### PR TITLE
feat: add chord detection and analyser

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,6 +65,7 @@
       <div class="track-info">
         <div id="current-track-name" class="track-name">No track loaded</div>
         <div id="current-track-duration" class="track-duration"></div>
+        <div id="chord-readout" class="chord-readout">—</div>
       </div>
 
       <div class="player-controls">

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -277,6 +277,20 @@ body.drag-over .app-container {
   color: var(--text-secondary);
 }
 
+.chord-readout {
+  margin-top: 6px;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 8px;
+  background: rgba(255,255,255,0.08);
+  border: 1px solid var(--border-color);
+  color: var(--text-color);
+}
+.chord-readout.pulse { box-shadow: 0 0 12px var(--playing-border); }
+
 .player-controls {
   flex-basis: 50%;
   display: flex;

--- a/src/js/renderer.js
+++ b/src/js/renderer.js
@@ -1,10 +1,14 @@
 import { AudioManager } from './audio-manager.js';
 import { Visualizer } from './visualizer.js';
+import { ChordDetector } from './chord-detector.js';
 
 class Renderer {
   constructor() {
     this.audioManager = new AudioManager();
     this.visualizer = new Visualizer('visualizer', this.audioManager.getAnalyser());
+    this.chordDetector = new ChordDetector(this.audioManager.getChordAnalyser(), {
+      sampleRate: this.audioManager.ctx.sampleRate
+    });
     
     // UI Elements
     this.addFilesBtn = document.getElementById('add-files-btn');
@@ -12,6 +16,7 @@ class Renderer {
     this.queueEl = document.getElementById('queue');
     this.trackNameEl = document.getElementById('current-track-name');
     this.trackDurationEl = document.getElementById('current-track-duration');
+    this.chordReadout = document.getElementById('chord-readout');
     this.playPauseBtn = document.getElementById('play-pause-btn');
     this.playIcon = document.getElementById('play-icon');
     this.pauseIcon = document.getElementById('pause-icon');
@@ -33,6 +38,17 @@ class Renderer {
     this.initEventListeners();
     this.initEqControls();
     this.initDragAndDrop();
+
+    // Start chord detector loop
+    this.chordDetector.setOnChord(({ name, confidence }) => {
+      if (this.chordReadout) {
+        const conf = Math.round(confidence * 100);
+        this.chordReadout.textContent = `${name}  ·  ${conf}%`;
+        this.chordReadout.classList.add('pulse');
+        setTimeout(() => this.chordReadout && this.chordReadout.classList.remove('pulse'), 120);
+      }
+    });
+    this.chordDetector.start();
   }
 
   initEventListeners() {


### PR DESCRIPTION
## Summary
- add dedicated chord analyser alongside visual analyser and master gain routing
- introduce chord detector capable of identifying major/minor, 7th, maj7, and 9 chords
- display detected chord in UI with new readout and styling

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a038136a98832ab47326d406ed1303