### PR TITLE
Fix chord detector configuration and tests

### DIFF
--- a/src/js/renderer.js
+++ b/src/js/renderer.js
@@ -8,11 +8,13 @@ class Renderer {
     this.visualizer = new Visualizer('visualizer', this.audioManager.getAnalyser());
     this.chordDetector = new ChordDetector(this.audioManager.getChordAnalyser(), {
       sampleRate: this.audioManager.ctx.sampleRate,
-      // Use a fairly conservative confidence and hold time so the readout
-      // only changes a couple of times per second and stays on chords the
-      // detector feels confident about.
-      minConfidence: 0.4,
-      holdMs: 500
+      // Configure chord detector to announce chords a little quicker and at a
+      // slightly lower confidence than the defaults.
+      confEnter: 0.4,
+      confExit: 0.32,
+      holdMsEnter: 500,
+      holdMsExit: 250,
+      requiredStableFrames: 2
     });
     
     // UI Elements
@@ -55,7 +57,8 @@ class Renderer {
       } else {
         const conf = Math.round(confidence * 100);
         this.chordReadout.textContent = `${name}  ·  ${conf}%`;
-        if (conf >= 62) {  // Match confEnter threshold of 0.62
+        const greenThresh = Math.round(this.chordDetector.confEnter * 100);
+        if (conf >= greenThresh) {
             this.chordReadout.style.color = '#4ade80'; // green-400
         } else {
             this.chordReadout.style.color = ''; // default color

--- a/test/chord-detector.test.js
+++ b/test/chord-detector.test.js
@@ -21,8 +21,11 @@ describe('ChordDetector', () => {
 
     const detector = new ChordDetector(analyser, {
       sampleRate,
-      minConfidence: 0,
-      holdMs: 0
+      confEnter: 0,
+      confExit: 0,
+      holdMsEnter: 0,
+      holdMsExit: 0,
+      requiredStableFrames: 1
     });
 
     let detected = null;
@@ -33,7 +36,7 @@ describe('ChordDetector', () => {
     detector.update();
 
     expect(detected).not.toBeNull();
-    expect(detected.name).toBe('C maj');
+    expect(detected.name).toBe('C');
   });
 
   it('pcToName wraps out-of-range values', () => {
@@ -51,8 +54,11 @@ describe('ChordDetector', () => {
 
     const detector = new ChordDetector(analyser, {
       sampleRate: 44100,
-      minConfidence: 0.9,
-      holdMs: 0
+      confEnter: 0.9,
+      confExit: 0.9,
+      holdMsEnter: 0,
+      holdMsExit: 0,
+      requiredStableFrames: 1
     });
 
     let called = false;


### PR DESCRIPTION
## Summary
- configure `ChordDetector` in renderer to use current API and tuned thresholds
- color chord readout based on configured confidence level
- update unit tests for new API and naming

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1fd1ad480832aa8c82b29f57385c4